### PR TITLE
feat: apply via Registry

### DIFF
--- a/contracts/projectRegistry/ProjectRegistry.sol
+++ b/contracts/projectRegistry/ProjectRegistry.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../utils/MetaPtr.sol";
+import "../round/RoundImplementation.sol";
 
 /**
  * @title ProjectRegistry
@@ -189,6 +190,31 @@ contract ProjectRegistry is Initializable {
         owners.count = 1;
     }
 
-    // Private functions
-    // ...
+    /**
+     * @notice submit an application of your project to a round
+     * @param projectID Id of project
+     * @param round address of round
+     * @param applicationMetaPtr meta pointer to the application
+     */
+    function applyToRound(
+        uint256 projectID,
+        address round,
+        MetaPtr calldata applicationMetaPtr
+    ) public onlyProjectOwner(projectID) {
+
+        bytes32 _projectID = bytes32(
+            abi.encodePacked(
+                block.chainid,
+                projectID,
+                address(this)
+            )
+        ); // TODO: figure out how to generate projectId 
+
+        RoundImplementation(
+            payable(round)
+        ).applyToRound(
+            _projectID,
+            applicationMetaPtr
+        );
+    }
 }

--- a/docs/contracts/projectRegistry/ProjectRegistry.md
+++ b/docs/contracts/projectRegistry/ProjectRegistry.md
@@ -27,6 +27,24 @@ Associate a new owner with a project
 | projectID | uint256 | ID of previously created project |
 | newOwner | address | address of new project owner |
 
+### applyToRound
+
+```solidity
+function applyToRound(uint256 projectID, address round, MetaPtr applicationMetaPtr) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| projectID | uint256 | undefined |
+| round | address | undefined |
+| applicationMetaPtr | MetaPtr | undefined |
+
 ### createProject
 
 ```solidity

--- a/docs/contracts/round/RoundImplementation.md
+++ b/docs/contracts/round/RoundImplementation.md
@@ -245,7 +245,7 @@ function initialize(bytes encodedParameters, address _roundFactory) external non
 
 Instantiates a new round
 
-*encodedParameters  - _initAddress Related contract / wallet addresses  - _initRoundTime Round timestamps  - _feePercentage Fee percentage  - _matchAmount Amount of tokens in the matching pool  - _token Address of the ERC20/native token for accepting matching pool contributions  - _initMetaPtr Round metaPtrs  - _initRoles Round roles*
+*encodedParameters  - _initAddress Related contract / wallet addresses  - _initRoundTime Round timestamps  - _initConfig Round config  - _initMetaPtr Round metaPtrs  - _initRoles Round roles*
 
 #### Parameters
 


### PR DESCRIPTION
#### Description 

Explores applyingToRound via the registry,
Every round on creation would be able to subscribe to a list of contracts from which applyToRound can be inoked (this could be project registry on the same chain / cross chain)

How are we doing this ? 

**ProjectRegistry**
- new function added on the registry which can be invoked by project owner to apply to a round

**RoundImplementation**
- new mapping which stores list of registries 
- update init to populate whitelisted registries 
- update applyToRound to check if msg.sender is whitelisted registries