### PR TITLE
Add virtual to init method in IVotingStrategy

### DIFF
--- a/contracts/votingStrategy/IVotingStrategy.sol
+++ b/contracts/votingStrategy/IVotingStrategy.sol
@@ -33,7 +33,7 @@ abstract contract IVotingStrategy {
    * set the round for which the voting contracts is to be used
    *
    */
-  function init() external {
+  function init() external virtual {
     require(roundAddress == address(0), "init: roundAddress already set");
     roundAddress = msg.sender;
   }


### PR DESCRIPTION
We recently merged a PR that added the `virtual` keyword to the `init()` method
of the payout strategy interface. This PR brings the voting strategy interface
to parity by adding `virtual` to the `init()` method there.
