### PR TITLE
update default accounts for local test nodes

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -40,8 +40,9 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 
 let deployPrivateKey = process.env.DEPLOYER_PRIVATE_KEY as string;
 if (!deployPrivateKey) {
+  // default first account deterministically created by local nodes like `npx hardhat node` or `anvil`
   deployPrivateKey =
-    "0x0000000000000000000000000000000000000000000000000000000000000001";
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 }
 
 const infuraIdKey = process.env.INFURA_ID as string;


### PR DESCRIPTION
instead of using the `0x00...1` private key for local development, I set the private key to be the same of the one deterministically generated by `hardhat node` and `anvil`.

This allows to easily deploy to a local node that can run independently and that can be used by other dapps like Grants Stack to test with local nodes.